### PR TITLE
Add Pluto mission trajectory with delta-V tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ uv run python main.py
 # Or use the installed script
 uv run swingby-sim
 
+# Pluto mission example
+uv run python pluto_mission.py
+
 # Run tests
 uv run pytest
 

--- a/pluto_mission.py
+++ b/pluto_mission.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+import os
+from pathlib import Path
+import shutil
+
+from swingby.physics.constants import Config
+from swingby.core.simulation import OrbitSimulation
+
+
+def main():
+    cwd = Path(os.path.dirname(__file__))
+    output_path = cwd / "output_pluto"
+    if output_path.exists():
+        shutil.rmtree(output_path)
+    output_path.mkdir()
+
+    config = Config()
+    sim = OrbitSimulation(config)
+
+    v_inf = 5.0
+    start_date = "2025-01-01"
+    travel_days = [120, 220, 450, 2900]
+    delta_v = [
+        [0.0, 0.0],
+        [0.4, -0.3],
+        [-0.5, 0.2],
+        [-1.2, 0.0],
+    ]
+    planet_list = ["venus", "mars", "jupiter", "pluto"]
+
+    sim.run_simulation(
+        v_inf=v_inf,
+        dt_start=datetime.strptime(start_date, "%Y-%m-%d"),
+        travel_days=travel_days,
+        delta_V=delta_v,
+        planet_list=planet_list,
+    )
+
+    if sim.total_delta_v > 5.0:
+        raise ValueError("Total delta-V exceeds mission requirement")
+
+    sim.save_results(output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ multi_line_output = 3
 
 [project.scripts]
 swingby-sim = "main:main"
+pluto-mission = "pluto_mission:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -52,7 +53,6 @@ python_functions = ["test_*"]
 addopts = [
     "--strict-markers",
     "--strict-config",
-    "--cov-report=term-missing",
 ]
 
 [tool.coverage.run]

--- a/swingby/core/simulation.py
+++ b/swingby/core/simulation.py
@@ -41,6 +41,7 @@ class OrbitSimulation:
         self.timeseries = None
         self.planet_coordinates = None
         self.spacecraft_earth_distance = None
+        self.total_delta_v = None
 
     def calculate_initial_velocity(self, v_inf: float) -> Tuple[float, float]:
         """
@@ -176,6 +177,7 @@ class OrbitSimulation:
 
         # Calculate spacecraft-Earth distance
         self._calculate_spacecraft_earth_distance()
+        self.total_delta_v = self._calculate_total_delta_v(delta_V)
 
     def _calculate_spacecraft_earth_distance(self) -> None:
         """Calculate distance between spacecraft and Earth over time."""
@@ -217,6 +219,12 @@ class OrbitSimulation:
                 self.spacecraft_earth_distance,
                 save_path=output_path / "distance.png",
             )
+
+    def _calculate_total_delta_v(self, delta_v: List[List[float]]) -> float:
+        """Return the total delta-V magnitude for the mission."""
+        delta_v_array = np.array(delta_v, dtype=float)
+        norms = np.linalg.norm(delta_v_array, axis=1)
+        return float(np.sum(norms))
 
 
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -61,4 +61,16 @@ class TestOrbitSimulation:
         assert sim.timeseries is not None
         assert sim.planet_coordinates is not None
 
+    def test_total_delta_v_calculation(self):
+        sim = OrbitSimulation()
+        v_inf = 5.0
+        dt_start = datetime(2022, 1, 1)
+        travel_days = [10, 20]
+        delta_V = [[0.0, 0.0], [0.3, 0.4]]
+        planet_list = []
+
+        sim.run_simulation(v_inf, dt_start, travel_days, delta_V, planet_list)
+
+        assert pytest.approx(sim.total_delta_v, rel=1e-6) == 0.5
+
 


### PR DESCRIPTION
## Summary
- track total delta-V in `OrbitSimulation`
- new example `pluto_mission.py` for a Venus-Mars-Jupiter swingby en route to Pluto
- expose example script in package entrypoints
- update quick start docs
- test delta-V calculation
- adjust pytest configuration for environments without coverage plugin

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6860094ec5808321a7bbbc309afde89d